### PR TITLE
chore: add meaningful errors for ip:port to multiaddr

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "dirty-chai": "^2.0.1"
   },
   "dependencies": {
+    "err-code": "^2.0.0",
     "ip-address": "^6.1.0",
     "multiaddr": "^7.1.0"
   },

--- a/src/ip-port-to-multiaddr.js
+++ b/src/ip-port-to-multiaddr.js
@@ -4,15 +4,21 @@ const multiaddr = require('multiaddr')
 const errCode = require('err-code')
 const { Address4, Address6 } = require('ip-address')
 
+const errors = {
+  ERR_INVALID_IP_PARAMETER: 'ERR_INVALID_IP_PARAMETER',
+  ERR_INVALID_PORT_PARAMETER: 'ERR_INVALID_PORT_PARAMETER',
+  ERR_INVALID_IP: 'ERR_INVALID_IP'
+}
+
 module.exports = (ip, port) => {
   if (typeof ip !== 'string') {
-    throw errCode(new Error('invalid ip provided', ip), 'ERR_INVALID_IP_PARAMETER')
+    throw errCode(new Error(`invalid ip provided: ${ip}`), errors.ERR_INVALID_IP_PARAMETER)
   }
 
   port = parseInt(port)
 
   if (isNaN(port)) {
-    throw errCode(new Error('invalid port provided', port), 'ERR_INVALID_PORT_PARAMETER')
+    throw errCode(new Error(`invalid port provided: ${port}`), errors.ERR_INVALID_PORT_PARAMETER)
   }
 
   if (new Address4(ip).isValid()) {
@@ -27,5 +33,7 @@ module.exports = (ip, port) => {
       : multiaddr(`/ip6/${ip}/tcp/${port}`)
   }
 
-  throw errCode(new Error('invalid ip:port for creating a multiaddr', ip, port), 'ERR_INVALID_IP')
+  throw errCode(new Error(`invalid ip:port for creating a multiaddr: ${ip}:${port}`), errors.ERR_INVALID_IP)
 }
+
+module.exports.Errors = errors

--- a/src/ip-port-to-multiaddr.js
+++ b/src/ip-port-to-multiaddr.js
@@ -1,17 +1,18 @@
 'use strict'
 
 const multiaddr = require('multiaddr')
+const errCode = require('err-code')
 const { Address4, Address6 } = require('ip-address')
 
 module.exports = (ip, port) => {
   if (typeof ip !== 'string') {
-    throw new Error('invalid ip')
+    throw errCode(new Error('invalid ip provided', ip), 'ERR_INVALID_IP_PARAMETER')
   }
 
   port = parseInt(port)
 
   if (isNaN(port)) {
-    throw new Error('invalid port')
+    throw errCode(new Error('invalid port provided', port), 'ERR_INVALID_PORT_PARAMETER')
   }
 
   if (new Address4(ip).isValid()) {
@@ -26,5 +27,5 @@ module.exports = (ip, port) => {
       : multiaddr(`/ip6/${ip}/tcp/${port}`)
   }
 
-  throw new Error('invalid ip')
+  throw errCode(new Error('invalid ip:port for creating a multiaddr', ip, port), 'ERR_INVALID_IP')
 }

--- a/test/ip-port-to-multiaddr.spec.js
+++ b/test/ip-port-to-multiaddr.spec.js
@@ -5,7 +5,9 @@ const chai = require('chai')
 const dirtyChai = require('dirty-chai')
 const expect = chai.expect
 chai.use(dirtyChai)
+
 const toMultiaddr = require('../src/ip-port-to-multiaddr')
+const { Errors } = require('../src/ip-port-to-multiaddr')
 
 describe('IP and port to Multiaddr', () => {
   it('creates multiaddr from valid IPv4 IP and port', () => {
@@ -33,18 +35,18 @@ describe('IP and port to Multiaddr', () => {
   })
 
   it('throws for missing IP address', () => {
-    expect(() => toMultiaddr()).to.throw('invalid ip provided')
+    expect(() => toMultiaddr()).to.throw('invalid ip provided').with.property('code', Errors.ERR_INVALID_IP_PARAMETER)
   })
 
   it('throws for invalid IP address', () => {
     const ip = 'aewmrn4awoew'
     const port = '234'
-    expect(() => toMultiaddr(ip, port)).to.throw('invalid ip:port for creating a multiaddr')
+    expect(() => toMultiaddr(ip, port)).to.throw('invalid ip:port for creating a multiaddr').with.property('code', Errors.ERR_INVALID_IP)
   })
 
   it('throws for invalid port', () => {
     const ip = '127.0.0.1'
     const port = 'garbage'
-    expect(() => toMultiaddr(ip, port)).to.throw('invalid port provided')
+    expect(() => toMultiaddr(ip, port)).to.throw('invalid port provided').with.property('code', Errors.ERR_INVALID_PORT_PARAMETER)
   })
 })

--- a/test/ip-port-to-multiaddr.spec.js
+++ b/test/ip-port-to-multiaddr.spec.js
@@ -33,18 +33,18 @@ describe('IP and port to Multiaddr', () => {
   })
 
   it('throws for missing IP address', () => {
-    expect(() => toMultiaddr()).to.throw('invalid ip')
+    expect(() => toMultiaddr()).to.throw('invalid ip provided')
   })
 
   it('throws for invalid IP address', () => {
     const ip = 'aewmrn4awoew'
     const port = '234'
-    expect(() => toMultiaddr(ip, port)).to.throw('invalid ip')
+    expect(() => toMultiaddr(ip, port)).to.throw('invalid ip:port for creating a multiaddr')
   })
 
   it('throws for invalid port', () => {
     const ip = '127.0.0.1'
     const port = 'garbage'
-    expect(() => toMultiaddr(ip, port)).to.throw('invalid port')
+    expect(() => toMultiaddr(ip, port)).to.throw('invalid port provided')
   })
 })


### PR DESCRIPTION
Added meaningful errors for `ip-port-to-multiaddr` util per discussion on #3 