### PR TITLE
chore: update deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "debug": "^4.1.1",
     "err-code": "^2.0.3",
     "ip-address": "^6.1.0",
-    "multiaddr": "multiformats/js-multiaddr#fix/replace-node-buffers-with-uint8arrays"
+    "multiaddr": "^8.0.0"
   },
   "contributors": [
     "Vasco Santos <vasco.santos@moxy.studio>"

--- a/package.json
+++ b/package.json
@@ -30,8 +30,6 @@
   "homepage": "https://github.com/libp2p/js-libp2p-utils#readme",
   "devDependencies": {
     "aegir": "^25.0.0",
-    "chai": "^4.2.0",
-    "dirty-chai": "^2.0.1",
     "it-pair": "^1.0.0",
     "it-pipe": "^1.1.0",
     "streaming-iterables": "^5.0.2"
@@ -41,7 +39,7 @@
     "debug": "^4.1.1",
     "err-code": "^2.0.3",
     "ip-address": "^6.1.0",
-    "multiaddr": "^7.5.0"
+    "multiaddr": "multiformats/js-multiaddr#fix/replace-node-buffers-with-uint8arrays"
   },
   "contributors": [
     "Vasco Santos <vasco.santos@moxy.studio>"

--- a/test/array-equals.spec.js
+++ b/test/array-equals.spec.js
@@ -1,11 +1,7 @@
 /* eslint-env mocha */
 'use strict'
 
-const chai = require('chai')
-const dirtyChai = require('dirty-chai')
-const expect = chai.expect
-chai.use(dirtyChai)
-
+const { expect } = require('aegir/utils/chai')
 const multiaddr = require('multiaddr')
 
 const arrayEquals = require('../src/array-equals')

--- a/test/ip-port-to-multiaddr.spec.js
+++ b/test/ip-port-to-multiaddr.spec.js
@@ -1,11 +1,7 @@
 /* eslint-env mocha */
 'use strict'
 
-const chai = require('chai')
-const dirtyChai = require('dirty-chai')
-const expect = chai.expect
-chai.use(dirtyChai)
-
+const { expect } = require('aegir/utils/chai')
 const toMultiaddr = require('../src/ip-port-to-multiaddr')
 const { Errors } = require('../src/ip-port-to-multiaddr')
 

--- a/test/stream-to-ma-conn.spec.js
+++ b/test/stream-to-ma-conn.spec.js
@@ -1,11 +1,7 @@
 /* eslint-env mocha */
 'use strict'
 
-const chai = require('chai')
-const dirtyChai = require('dirty-chai')
-const expect = chai.expect
-chai.use(dirtyChai)
-
+const { expect } = require('aegir/utils/chai')
 const pair = require('it-pair')
 const pipe = require('it-pipe')
 const { collect } = require('streaming-iterables')


### PR DESCRIPTION
Pulls in the latest multiaddrs that replaces node Buffers with Uint8Arrays

BREAKING CHANGES:

- The multiaddr dep of this module uses Uint8Arrays and may not be
  compatible with previous versions