### PR TITLE
feat: address sorter

### DIFF
--- a/API.md
+++ b/API.md
@@ -1,5 +1,9 @@
 # API
 
+* [addressSort.publicAddressesFirst(addresses)](#addresssortpublicaddressesfirstaddresses)
+    * [Parameters](#parameters)
+    * [Returns](#returns)
+    * [Example](#example)
 * [arrayEquals(a, b)](#arrayequalsa-b)
     * [Parameters](#parameters)
     * [Returns](#returns)
@@ -20,6 +24,42 @@
     * [Parameters](#parameters-4)
     * [Returns](#returns-4)
     * [Example](#example-4)
+
+## addressSort.publicAddressesFirst(addresses)
+
+Sort given addresses by putting public addresses first. In case of equality, a certified address will come first.
+
+### Parameters
+
+| Name | Type | Description |
+|------|------|-------------|
+| addresses | `Array<Address>` | Array of AddressBook addresses |
+
+### Returns
+
+| Type | Description |
+|------|-------------|
+| `Array<Address>` | returns array of sorted addresses |
+
+### Example
+
+```js
+const multiaddr = require('multiaddr')
+const { publicAddressesFirst } = require('../src/address-sort')
+
+const addresses = [
+    {
+        multiaddr: multiaddr('/ip4/127.0.0.1/tcp/4000'),
+        isCertified: false
+    },
+    {
+        multiaddr: multiaddr('/ip4/30.0.0.1/tcp/4000'),
+        isCertified: false
+    }
+]
+
+const sortedAddresses = publicAddressesFirst(addresses)
+```
 
 ## arrayEquals(a, b)
 

--- a/API.md
+++ b/API.md
@@ -45,7 +45,7 @@ Sort given addresses by putting public addresses first. In case of equality, a c
 
 ```js
 const multiaddr = require('multiaddr')
-const { publicAddressesFirst } = require('../src/address-sort')
+const { publicAddressesFirst } = require('libp2p-utils/src/address-sort')
 
 const addresses = [
     {

--- a/src/address-sort.js
+++ b/src/address-sort.js
@@ -5,7 +5,7 @@ const isPrivate = require('./multiaddr/is-private')
 /**
  * Compare function for array.sort().
  * This sort aims to move the private adresses to the end of the array.
- * In case of equality, a cerified address will come first.
+ * In case of equality, a certified address will come first.
  *
  * @param {Address} a
  * @param {Address} b

--- a/src/address-sort.js
+++ b/src/address-sort.js
@@ -1,0 +1,44 @@
+'use strict'
+
+const isPrivate = require('./multiaddr/is-private')
+
+/**
+ * Compare function for array.sort().
+ * This sort aims to move the private adresses to the end of the array.
+ * In case of equality, a cerified address will come first.
+ *
+ * @param {Address} a
+ * @param {Address} b
+ * @returns {number}
+ */
+function addressesPublicFirstCompareFunction (a, b) {
+  const isAPrivate = isPrivate(a.multiaddr)
+  const isBPrivate = isPrivate(b.multiaddr)
+
+  if (isAPrivate && !isBPrivate) {
+    return 1
+  } else if (!isAPrivate && isBPrivate) {
+    return -1
+  }
+  // Check certified?
+  if (a.isCertified && !b.isCertified) {
+    return -1
+  } else if (!a.isCertified && b.isCertified) {
+    return 1
+  }
+
+  return 0
+}
+
+/**
+ * Sort given addresses by putting public addresses first.
+ * In case of equality, a certified address will come first.
+ *
+ * @param {Array<Address>} addresses
+ * @returns {Array<Address>}
+ */
+function publicAddressesFirst (addresses) {
+  return [...addresses].sort(addressesPublicFirstCompareFunction)
+}
+
+module.exports.publicAddressesFirst = publicAddressesFirst

--- a/test/address-sort.spec.js
+++ b/test/address-sort.spec.js
@@ -1,0 +1,53 @@
+'use strict'
+/* eslint-env mocha */
+
+const { expect } = require('aegir/utils/chai')
+const multiaddr = require('multiaddr')
+
+const { publicAddressesFirst } = require('../src/address-sort')
+
+describe('address-sort', () => {
+  it('should sort public addresses first', () => {
+    const addresses = [
+      {
+        multiaddr: multiaddr('/ip4/127.0.0.1/tcp/4000'),
+        isCertified: false
+      },
+      {
+        multiaddr: multiaddr('/ip4/30.0.0.1/tcp/4000'),
+        isCertified: false
+      },
+      {
+        multiaddr: multiaddr('/ip4/31.0.0.1/tcp/4000'),
+        isCertified: false
+      }
+    ]
+
+    const sortedAddresses = publicAddressesFirst(addresses)
+    expect(sortedAddresses[0].multiaddr.equals(multiaddr('/ip4/30.0.0.1/tcp/4000'))).to.eql(true)
+    expect(sortedAddresses[1].multiaddr.equals(multiaddr('/ip4/31.0.0.1/tcp/4000'))).to.eql(true)
+    expect(sortedAddresses[2].multiaddr.equals(multiaddr('/ip4/127.0.0.1/tcp/4000'))).to.eql(true)
+  })
+
+  it('should sort public certified addresses first', () => {
+    const addresses = [
+      {
+        multiaddr: multiaddr('/ip4/127.0.0.1/tcp/4000'),
+        isCertified: false
+      },
+      {
+        multiaddr: multiaddr('/ip4/30.0.0.1/tcp/4000'),
+        isCertified: false
+      },
+      {
+        multiaddr: multiaddr('/ip4/31.0.0.1/tcp/4000'),
+        isCertified: true
+      }
+    ]
+
+    const sortedAddresses = publicAddressesFirst(addresses)
+    expect(sortedAddresses[0].multiaddr.equals(multiaddr('/ip4/31.0.0.1/tcp/4000'))).to.eql(true)
+    expect(sortedAddresses[1].multiaddr.equals(multiaddr('/ip4/30.0.0.1/tcp/4000'))).to.eql(true)
+    expect(sortedAddresses[2].multiaddr.equals(multiaddr('/ip4/127.0.0.1/tcp/4000'))).to.eql(true)
+  })
+})


### PR DESCRIPTION
This PR adds the address sorter utility with a `sortPublicAddressesFirst` sorter.