### PR TITLE
fix: pass duplex to stream-to-ma-conn not stream

### DIFF
--- a/package.json
+++ b/package.json
@@ -176,6 +176,7 @@
     "abortable-iterator": "^4.0.2",
     "err-code": "^3.0.1",
     "is-loopback-addr": "^2.0.1",
+    "it-stream-types": "^1.0.4",
     "private-ip": "^2.1.1"
   },
   "devDependencies": {

--- a/src/address-sort.ts
+++ b/src/address-sort.ts
@@ -7,19 +7,9 @@ interface Address {
 }
 
 /**
- * @typedef {Object} Address
- * @property {Multiaddr} multiaddr peer multiaddr.
- * @property {boolean} isCertified obtained from a signed peer record.
- */
-
-/**
  * Compare function for array.sort().
  * This sort aims to move the private adresses to the end of the array.
  * In case of equality, a certified address will come first.
- *
- * @param {Address} a
- * @param {Address} b
- * @returns {number}
  */
 function addressesPublicFirstCompareFunction (a: Address, b: Address) {
   const isAPrivate = isPrivate(a.multiaddr)

--- a/src/stream-to-ma-conn.ts
+++ b/src/stream-to-ma-conn.ts
@@ -1,17 +1,10 @@
 import { abortableSource } from 'abortable-iterator'
 import { logger } from '@libp2p/logger'
-import type { Stream } from '@libp2p/interfaces/connection'
 import type { Multiaddr } from '@multiformats/multiaddr'
 import type { MultiaddrConnection } from '@libp2p/interfaces/transport'
+import type { Duplex } from 'it-stream-types'
 
 const log = logger('libp2p:stream:converter')
-
-/**
- * @typedef {Object} Timeline
- * @property {number} open -
- * @property {number} [upgraded] - .
- * @property {number} [close]
- */
 
 export interface Timeline {
   /**
@@ -36,7 +29,7 @@ interface StreamOptions {
 }
 
 interface StreamProperties {
-  stream: Stream
+  stream: Duplex<Uint8Array>
   remoteAddr: Multiaddr
   localAddr: Multiaddr
 }


### PR DESCRIPTION
Stream is a (possibly) multiplexed stream which comes later in the flow.  stream-to-ma-conn takes the low-level byte stream.

Also removes some redundant comments.