### PR TITLE
fix: refactor address sort to be a regular sort function

### DIFF
--- a/src/address-sort.ts
+++ b/src/address-sort.ts
@@ -1,17 +1,12 @@
-import type { Multiaddr } from '@multiformats/multiaddr'
+import type { Address } from '@libp2p/interfaces/peer-store'
 import { isPrivate } from './multiaddr/is-private.js'
-
-interface Address {
-  multiaddr: Multiaddr
-  isCertified: boolean
-}
 
 /**
  * Compare function for array.sort().
- * This sort aims to move the private adresses to the end of the array.
+ * This sort aims to move the private addresses to the end of the array.
  * In case of equality, a certified address will come first.
  */
-function addressesPublicFirstCompareFunction (a: Address, b: Address) {
+export function publicAddressesFirst (a: Address, b: Address): -1 | 0 | 1 {
   const isAPrivate = isPrivate(a.multiaddr)
   const isBPrivate = isPrivate(b.multiaddr)
 
@@ -28,12 +23,4 @@ function addressesPublicFirstCompareFunction (a: Address, b: Address) {
   }
 
   return 0
-}
-
-/**
- * Sort given addresses by putting public addresses first.
- * In case of equality, a certified address will come first.
- */
-export function publicAddressesFirst (addresses: Address[]) {
-  return [...addresses].sort(addressesPublicFirstCompareFunction)
 }

--- a/test/address-sort.spec.ts
+++ b/test/address-sort.spec.ts
@@ -21,7 +21,7 @@ describe('address-sort', () => {
       }
     ]
 
-    const sortedAddresses = publicAddressesFirst(addresses)
+    const sortedAddresses = addresses.sort(publicAddressesFirst)
     expect(sortedAddresses[0].multiaddr.equals(new Multiaddr('/ip4/30.0.0.1/tcp/4000'))).to.eql(true)
     expect(sortedAddresses[1].multiaddr.equals(new Multiaddr('/ip4/31.0.0.1/tcp/4000'))).to.eql(true)
     expect(sortedAddresses[2].multiaddr.equals(new Multiaddr('/ip4/127.0.0.1/tcp/4000'))).to.eql(true)
@@ -43,7 +43,7 @@ describe('address-sort', () => {
       }
     ]
 
-    const sortedAddresses = publicAddressesFirst(addresses)
+    const sortedAddresses = addresses.sort(publicAddressesFirst)
     expect(sortedAddresses[0].multiaddr.equals(new Multiaddr('/ip4/31.0.0.1/tcp/4000'))).to.eql(true)
     expect(sortedAddresses[1].multiaddr.equals(new Multiaddr('/ip4/30.0.0.1/tcp/4000'))).to.eql(true)
     expect(sortedAddresses[2].multiaddr.equals(new Multiaddr('/ip4/127.0.0.1/tcp/4000'))).to.eql(true)


### PR DESCRIPTION
Instead of taking a list of addresses and sorting them, refactor the `publicAddressesFirst` function to be one that you can pass to `Array.sort` and friends.