### PR TITLE
chore(deps)!: bump @libp2p/interface-connection from 1.0.1 to 2.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -172,7 +172,7 @@
   },
   "dependencies": {
     "@achingbrain/ip-address": "^8.1.0",
-    "@libp2p/interface-connection": "^1.0.1",
+    "@libp2p/interface-connection": "^2.1.0",
     "@libp2p/interface-peer-store": "^1.0.0",
     "@libp2p/interface-transport": "^1.0.0",
     "@libp2p/logger": "^2.0.0",

--- a/test/stream-to-ma-conn.spec.ts
+++ b/test/stream-to-ma-conn.spec.ts
@@ -18,9 +18,13 @@ function toMuxedStream (stream: Duplex<Uint8Array>) {
     closeWrite: () => {},
     abort: () => {},
     reset: () => {},
-    timeline: {
-      open: Date.now()
+    stat: {
+      direction: 'outbound',
+      timeline: {
+        open: Date.now()
+      }
     },
+    metadata: {},
     id: `muxed-stream-${Math.random()}`
   }
 


### PR DESCRIPTION
BREAKING CHANGE: the API of the returned MultiaddrConnection has changed