### PR TITLE
fix: handle non ip4/ip6/dns addresses in isPrivate

### DIFF
--- a/src/multiaddr/is-private.ts
+++ b/src/multiaddr/is-private.ts
@@ -5,7 +5,11 @@ import isIpPrivate from 'private-ip'
  * Check if a given multiaddr has a private address.
  */
 export function isPrivate (ma: Multiaddr): boolean {
-  const { address } = ma.nodeAddress()
+  try {
+    const { address } = ma.nodeAddress()
 
-  return Boolean(isIpPrivate(address))
+    return Boolean(isIpPrivate(address))
+  } catch {
+    return true
+  }
 }

--- a/test/multiaddr/is-private.spec.ts
+++ b/test/multiaddr/is-private.spec.ts
@@ -53,4 +53,14 @@ describe('multiaddr isPrivate', () => {
       expect(isPrivate(ma)).to.eql(false)
     })
   })
+
+  it('identifies non-public addresses', () => {
+    [
+      multiaddr('/ip4/127.0.0.1/tcp/1000/p2p-circuit'),
+      multiaddr('/unix/foo/bar/baz.sock'),
+      multiaddr('/ip4/127.0.0.1/sctp/1000')
+    ].forEach(ma => {
+      expect(isPrivate(ma)).to.eql(true)
+    })
+  })
 })


### PR DESCRIPTION
Update code to allow returning true for addresses that are not publicly routable but are valid like unix sockets.